### PR TITLE
[torch.fx] Fix pattern matching the same node multiple times

### DIFF
--- a/test/fx/test_subgraph_rewriter.py
+++ b/test/fx/test_subgraph_rewriter.py
@@ -489,4 +489,3 @@ class TestSubgraphRewriter(JitTestCase):
         ref_outs = comparison_fn(x)
         test_outs = traced.forward(x)
         self.assertEqual(ref_outs, test_outs)
-

--- a/test/fx/test_subgraph_rewriter.py
+++ b/test/fx/test_subgraph_rewriter.py
@@ -489,3 +489,61 @@ class TestSubgraphRewriter(JitTestCase):
         ref_outs = comparison_fn(x)
         test_outs = traced.forward(x)
         self.assertEqual(ref_outs, test_outs)
+
+    def test_subgraph_rewriter_replaces_parallel_functions(self):
+        def f(x):
+            y = torch.sigmoid(x)
+            z = torch.sigmoid(x)
+            return y, z
+
+        def pattern(x):
+            return torch.sigmoid(x)
+
+        def replacement(x):
+            return torch.relu(x)
+
+        def comparison(x):
+            y = torch.relu(x)
+            z = torch.relu(x)
+            return y, z
+
+        traced = symbolic_trace(f)
+
+        print(traced.graph)
+        subgraph_rewriter.replace_pattern(traced, pattern, replacement)
+        print(traced.graph)
+        traced.graph.lint()
+
+        x = torch.randn(3, 4)
+        ref_outs = comparison(x)
+        test_outs = traced.forward(x)
+        self.assertEqual(ref_outs, test_outs)
+
+    def test_subgraph_rewriter_replaces_parallel_functions_when_agregated(self):
+        def f(x):
+            y = torch.sigmoid(x)
+            z = torch.sigmoid(x)
+            return y + z
+
+        def pattern(x):
+            return torch.sigmoid(x)
+
+        def replacement(x):
+            return torch.relu(x)
+
+        def comparison(x):
+            y = torch.relu(x)
+            z = torch.relu(x)
+            return y + z
+
+        traced = symbolic_trace(f)
+
+        print(traced.graph)
+        subgraph_rewriter.replace_pattern(traced, pattern, replacement)
+        print(traced.graph)
+        traced.graph.lint()
+
+        x = torch.randn(3, 4)
+        ref_outs = comparison(x)
+        test_outs = traced.forward(x)
+        self.assertEqual(ref_outs, test_outs)

--- a/test/fx/test_subgraph_rewriter.py
+++ b/test/fx/test_subgraph_rewriter.py
@@ -458,3 +458,35 @@ class TestSubgraphRewriter(JitTestCase):
             if n.op == 'placeholder':
                 assert n.type == int
                 assert m.type == int
+
+    def test_subgraph_writer_replace_consecutive_submodules(self):
+
+        def f(x):
+            x = torch.sigmoid(x)
+            x = torch.sigmoid(x)
+            return torch.sigmoid(x)
+
+        def pattern(x):
+            return torch.sigmoid(x)
+
+        def replacement(x):
+            return torch.exp(x)
+
+        def comparison(x):
+            x = torch.exp(x)
+            x = torch.exp(x)
+            return torch.exp(x)
+
+        traced = symbolic_trace(f)
+        comparison_fn = symbolic_trace(comparison)
+
+        x = torch.randn(3, 4)
+
+        subgraph_rewriter.replace_pattern(traced, pattern, replacement)
+
+        traced.graph.lint()
+
+        ref_outs = comparison_fn(x)
+        test_outs = traced.forward(x)
+        self.assertEqual(ref_outs, test_outs)
+

--- a/test/fx/test_subgraph_rewriter.py
+++ b/test/fx/test_subgraph_rewriter.py
@@ -509,9 +509,7 @@ class TestSubgraphRewriter(JitTestCase):
 
         traced = symbolic_trace(f)
 
-        print(traced.graph)
         subgraph_rewriter.replace_pattern(traced, pattern, replacement)
-        print(traced.graph)
         traced.graph.lint()
 
         x = torch.randn(3, 4)
@@ -519,7 +517,7 @@ class TestSubgraphRewriter(JitTestCase):
         test_outs = traced.forward(x)
         self.assertEqual(ref_outs, test_outs)
 
-    def test_subgraph_rewriter_replaces_parallel_functions_when_agregated(self):
+    def test_subgraph_rewriter_replaces_parallel_functions_when_aggregated(self):
         def f(x):
             y = torch.sigmoid(x)
             z = torch.sigmoid(x)
@@ -538,9 +536,7 @@ class TestSubgraphRewriter(JitTestCase):
 
         traced = symbolic_trace(f)
 
-        print(traced.graph)
         subgraph_rewriter.replace_pattern(traced, pattern, replacement)
-        print(traced.graph)
         traced.graph.lint()
 
         x = torch.randn(3, 4)

--- a/torch/fx/subgraph_rewriter.py
+++ b/torch/fx/subgraph_rewriter.py
@@ -131,7 +131,7 @@ def _replace_submodules(gm: GraphModule, replacement: torch.nn.Module) -> None:
 
     gm.graph.lint()
 
-def add_suffix_to_graph(graph, suffix):
+def _add_suffix_to_graph(graph, suffix):
     for node in graph.nodes:
         node.name += suffix
 
@@ -327,7 +327,7 @@ def replace_pattern(gm: GraphModule, pattern: Callable, replacement: Callable) -
             continue
 
         suffixed_replacement_graph = replacement_graph.__deepcopy__()
-        add_suffix_to_graph(suffixed_replacement_graph, f"_{i}")
+        _add_suffix_to_graph(suffixed_replacement_graph, f"_{i}")
         # Map replacement graph nodes to their copy in `original_graph`
         val_map: Dict[Node, Node] = {}
 
@@ -401,7 +401,7 @@ def replace_pattern(gm: GraphModule, pattern: Callable, replacement: Callable) -
                 for pn_input, rn_input in zip(pn.all_input_nodes, rn.all_input_nodes):
                     gn_input = match.nodes_map[pn_input]
                     rn_input_in_original_graph = val_map[rn_input]
-                    gn.replace_input_with(gn_input, rn_input_in_original_graph)
+                    gn_input.replace_all_uses_with(rn_input_in_original_graph)
                     # We store the updated node point in case other nodes want to use it
                     match_changed_node[gn_input] = rn_input_in_original_graph
 


### PR DESCRIPTION
Related to  https://github.com/pytorch/pytorch/pull/66442

```python
def f(x):
    y = torch.sigmoid(x)
    z = torch.sigmoid(x)
    return y + z

def pattern(x):
    return torch.sigmoid(x)

def replacement(x):
    return torch.relu(x)

def comparison(x):
    y = torch.relu(x)
    z = torch.relu(x)
    return y + z

traced = symbolic_trace(f)

subgraph_rewriter.replace_pattern(traced, pattern, replacement) # This replaces only one sigmoid
```

As shown in the code previously, we allow a single node to match a pattern multiple time. This is need if you look at the traced `f`:

```
# Tracing f
.graph():
    %x : [#users=2] = placeholder[target=x]
    %sigmoid : [#users=1] = call_function[target=torch.sigmoid](args = (%x,), kwargs = {})
    %sigmoid_1 : [#users=1] = call_function[target=torch.sigmoid](args = (%x,), kwargs = {})
    %add : [#users=1] = call_function[target=operator.add](args = (%sigmoid, %sigmoid_1), kwargs = {})
    return add
 ```